### PR TITLE
feat: add http status code support

### DIFF
--- a/src/mock/xhr/xhr.js
+++ b/src/mock/xhr/xhr.js
@@ -285,14 +285,14 @@ Util.extend(MockXMLHttpRequest.prototype, {
             that.readyState = MockXMLHttpRequest.LOADING
             that.dispatchEvent(new Event('readystatechange' /*, false, false, that*/ ))
 
-            that.status = 200
-            that.statusText = HTTP_STATUS_CODES[200]
-
             // fix #92 #93 by @qddegtya
             that.response = that.responseText = JSON.stringify(
                 convert(that.custom.template, that.custom.options),
                 null, 4
             )
+
+            that.status = that.custom.options.status || 200
+            that.statusText = HTTP_STATUS_CODES[that.status]
 
             that.readyState = MockXMLHttpRequest.DONE
             that.dispatchEvent(new Event('readystatechange' /*, false, false, that*/ ))
@@ -435,8 +435,15 @@ function find(options) {
 
 // 数据模板 ＝> 响应数据
 function convert(item, options) {
-    return Util.isFunction(item.template) ?
-        item.template(options) : MockXMLHttpRequest.Mock.mock(item.template)
+    if (Util.isFunction(item.template)) {
+        var data = item.template(options)
+        // 数据模板中的返回参构造处理
+        // _status 控制返回状态码
+        data._status && data._status !== 0 && (options.status = data._status)
+        delete data._status
+        return data
+    }
+    return MockXMLHttpRequest.Mock.mock(item.template)
 }
 
 module.exports = MockXMLHttpRequest


### PR DESCRIPTION
**feature**  add http status code
fix #140 #259 

eg:
```
const login = (options) => {
  const body = JSON.parse(options.body)
  const username = ['admin', 'user', 'super']
  const password = ['admin', 'user', 'super']
  if (!username.includes(body.username) || !password.includes(body.password)) {
    return {
      // 业务状态
      code: -1,
      data: null,
      message: '账号或密码错误',
      // _ 开头的返回体第一层数据 _status 作为 mock 返回的状态码
      // 不传值默认 200
      _status: 401
      // 同理可增加 _headers 自定义返回头
    }
  }

  return {
    // 业务状态
    code: 0,
    data: {
      'id': Mock.mock('@guid'),
      'name': Mock.mock('@name'),
      'username': 'admin',
      'token': Mock.mock('@guid')
    },
    message: '登录成功'
  }
}
```

```js
Mock.mock(/\/auth\/login/, 'post', login)
```

__This PR allow edits from maintainers.__