### PR TITLE
fix: fail to mock when use capital request method

### DIFF
--- a/src/mock/xhr/xhr.js
+++ b/src/mock/xhr/xhr.js
@@ -415,7 +415,7 @@ function find(options) {
         var item = MockXMLHttpRequest.Mock._mocked[sUrlType]
         if (
             (!item.rurl || match(item.rurl, options.url)) &&
-            (!item.rtype || match(item.rtype, options.type.toLowerCase()))
+            (!item.rtype || match(item.rtype.toLowerCase(), options.type.toLowerCase()))
         ) {
             // console.log('[mock]', options.url, '>', item.rurl)
             return item


### PR DESCRIPTION
Mock.mock(rurl,rtype,template)修复请求方式rtype为大写如POST,Post无法拦截xhr请求问题