### PR TITLE
fix:处理小数位数为0时导致栈溢出的问题

### DIFF
--- a/src/mock/parser.js
+++ b/src/mock/parser.js
@@ -43,7 +43,8 @@ module.exports = {
 		var dmin = decimal && decimal[1] && parseInt(decimal[1], 10) // || 0,
 		var dmax = decimal && decimal[2] && parseInt(decimal[2], 10) // || 0,
 			// int || dmin-dmax || 0
-		var dcount = decimal ? !decimal[2] && parseInt(decimal[1], 10) || Random.integer(dmin, dmax) : undefined
+		// var dcount = decimal ? !decimal[2] && parseInt(decimal[1], 10) || Random.integer(dmin, dmax) : undefined
+		var dcount = decimal ? !decimal[2] && decimal[1] ? parseInt(decimal[1], 10) : Random.integer(dmin, dmax) : undefined
 
 		var result = {
 			// 1 name, 2 inc, 3 range, 4 decimal


### PR DESCRIPTION
`
const mock = require("mockjs")

var json = {
    "plantArea|0-5.0": 0
}

mock.mock(obj)
`
小数位填0时会导致栈溢出