### PR TITLE
fix withCredentials=true

### DIFF
--- a/src/mock/xhr/xhr.js
+++ b/src/mock/xhr/xhr.js
@@ -223,13 +223,6 @@ Util.extend(MockXMLHttpRequest.prototype, {
             if (username) xhr.open(method, url, async, username, password)
             else xhr.open(method, url, async)
 
-            // 同步属性 MockXMLHttpRequest => NativeXMLHttpRequest
-            for (var j = 0; j < XHR_REQUEST_PROPERTIES.length; j++) {
-                try {
-                    xhr[XHR_REQUEST_PROPERTIES[j]] = that[XHR_REQUEST_PROPERTIES[j]]
-                } catch (e) {}
-            }
-
             return
         }
 
@@ -264,7 +257,14 @@ Util.extend(MockXMLHttpRequest.prototype, {
 
         // 原生 XHR
         if (!this.match) {
-            this.custom.xhr.send(data)
+            var xhr = this.custom.xhr
+            // 同步属性 MockXMLHttpRequest => NativeXMLHttpRequest
+            for (var j = 0; j < XHR_REQUEST_PROPERTIES.length; j++) {
+                try {
+                    xhr[XHR_REQUEST_PROPERTIES[j]] = this[XHR_REQUEST_PROPERTIES[j]]
+                } catch (e) {}
+            }
+            xhr.send(data)
             return
         }
 


### PR DESCRIPTION
修复xhr.withCredentials = true 不生效的bug
下方写法不生效
```js
      const xhr = new XMLHttpRequest()
      xhr.open('GET', url)
      xhr.withCredentials = true
      xhr.send()
```
将` xhr.withCredentials = true `写在` xhr.open() `之前生效，是因为下方node_modules/mockjs/src/mock/xhr/xhr.js line226行**for循环**在起作用

同理，将` xhr.withCredentials = true `写在` xhr.open() `之后，并不会执行将自定义属性赋值给原生的过程
