### PR TITLE
Update mock.js

### DIFF
--- a/dist/mock.js
+++ b/dist/mock.js
@@ -454,7 +454,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	                }
 
 	                phed = Handler.placeholder(ph, options.context.currentContext, options.context.templateCurrentContext, options)
-
+					if(phed.indexOf('$')>-1){
+						phed=phed.replace(/\$/g,'$ ');
+					}
 	                // 只有一个占位符，并且没有其他字符
 	                if (placeholders.length === 1 && ph === result && typeof phed !== typeof result) { // 
 	                    result = phed
@@ -479,7 +481,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            // 'ASCII': '',
 	            result = options.rule.range ? Random.string(options.rule.count) : options.template
 	        }
-	        return result
+			return  result.indexOf(' ')>-1?result.replace(/ /g,''):result;
 	    },
 	    'function': function(options) {
 	        // ( context, options )

--- a/src/mock/handler.js
+++ b/src/mock/handler.js
@@ -326,7 +326,9 @@ Handler.extend({
                 }
 
                 phed = Handler.placeholder(ph, options.context.currentContext, options.context.templateCurrentContext, options)
-
+                if(phed.indexOf('$')>-1){
+                    phed=phed.replace(/\$/g,'$ ');
+                }
                 // 只有一个占位符，并且没有其他字符
                 if (placeholders.length === 1 && ph === result && typeof phed !== typeof result) { // 
                     result = phed
@@ -351,7 +353,7 @@ Handler.extend({
             // 'ASCII': '',
             result = options.rule.range ? Random.string(options.rule.count) : options.template
         }
-        return result
+        return  result.indexOf(' ')>-1?result.replace(/ /g,''):result;
     },
     'function': function(options) {
         // ( context, options )


### PR DESCRIPTION
在mock.js文件中的string方法这边，字符串替换的时候需要对$符号做特殊处理，
主要是result = result.replace(ph, phed);这一句用到了正则表达式，
而 $$ $& $` $' $n $<分组名称>这些组合是有特殊含义的